### PR TITLE
feat: add ci to deploy game to github pages site [9]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      # Runs a single command using the runners shell
+      - name: Build game
+        run: |
+          npm install
+          npm run build -- --public-url /breakout-excaliburjs
+      # Runs a set of commands using the runners shell
+      - name: Deploy to GitHub Pages
+        # You may pin to the exact commit or the version.
+        # uses: JamesIves/github-pages-deploy-action@164583b9e44b4fc5910e78feb607ea7c98d3c7b9
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          # This is the branch you wish to deploy to, for example gh-pages or docs.
+          branch: gh-pages
+          # The folder in your repository that you want to deploy. If your build script compiles into a directory named build you would put it here. Folder paths cannot have a leading / or ./. If you wish to deploy the root directory you can place a . here.
+          folder: dist
+          # If you would like to push the contents of the deployment folder into a specific directory on the deployment branch you can specify it here.
+          # target-folder: .
+          # If you need to customize the commit message for an integration you can do so.
+          commit-message: Deploy game


### PR DESCRIPTION
Following template: https://github.com/excaliburjs/ludum-50/blob/main/.github/workflows/main.yml

Closes #9, if deployment is successful on merge. Further attempts or cleanup may be needed.